### PR TITLE
Start new attempt form

### DIFF
--- a/src/Controller/CharactersController.php
+++ b/src/Controller/CharactersController.php
@@ -147,7 +147,7 @@ class CharactersController extends AbstractController
      *
      * @return Response
      **/
-    #[Route('/characters/{characterId}/previous/{attemptId}', name: 'app_previous')]
+    #[Route('/previous/{characterId}/{attemptId}', name: 'app_previous')]
     public function previousIndex(string $characterId, string $attemptId): Response
     {
         $character = $this->getCharacter($characterId);
@@ -177,7 +177,8 @@ class CharactersController extends AbstractController
                 'active_player' => $character->getPlayer()->getId(),
                 'character' => $character,
                 'attempt' => $attempt,
-                'milestones' => $previousMilestones
+                'milestones' => $previousMilestones,
+                'current_attempt' => $attempt
             ]
         );
     }

--- a/src/Form/NewAttemptType.php
+++ b/src/Form/NewAttemptType.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Symfony FormType for Attempt Entity
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   Games-projecttiy-com
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://mit-license.org/ MIT
+ * @version   CVS: $Id:$
+ * @link      https://github.com/benowe1717/games-projecttiy-com
+ **/
+
+namespace App\Form;
+
+use App\Entity\Attempt;
+use App\Entity\Character;
+use App\Entity\Milestone;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Symfony FormType for Attempt Entity
+ *
+ * PHP version 8.3
+ *
+ * @category  Form
+ * @package   Games-projecttiy-com
+ * @author    Benjamin Owen <benjamin@projecttiy.com>
+ * @copyright 2024 Benjamin Owen
+ * @license   https://mit-license.org/ MIT
+ * @version   Release: 0.0.1
+ * @link      https://github.com/benowe1717/games-projecttiy-com
+ **/
+class NewAttemptType extends AbstractType
+{
+    /**
+     * Build the Form Interface for the Controller to render
+     *
+     * @param FormBuilderInterface $builder FormBuilderInterface
+     * @param array                $options Options for Form Builder
+     *
+     * @return void
+     **/
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'characterId',
+                EntityType::class,
+                [
+                    'class' => Character::class,
+                    'choices' => $options['characters'],
+                    'choice_label' => 'name',
+                    'choice_value' => 'id',
+                    'label' => 'Character',
+                ]
+            )
+            ->add(
+                'causeOfDeath',
+                TextType::class,
+                [
+                    'label' => 'Cause of death?',
+                ]
+            )
+            ->add(
+                'submit',
+                SubmitType::class,
+                [
+                    'label' => 'Start',
+                ]
+            );
+        // $builder
+        //     ->add('attemptNumber')
+        //     ->add('isCurrent')
+        //     ->add('timePlayed')
+        //     ->add('causeOfDeath')
+        //     ->add('adventureLevel')
+        //     ->add('characterId', EntityType::class, [
+        //         'class' => Character::class,
+        //         'choice_label' => 'id',
+        //     ])
+        //     ->add('milestones', EntityType::class, [
+        //         'class' => Milestone::class,
+        //         'choice_label' => 'id',
+        //         'multiple' => true,
+        //     ])
+        // ;
+    }
+
+    /**
+     * Pass the needed Data Classes to the Form Builder
+     *
+     * @param OptionsResolver $resolver The resolver from Class Objects to Form
+     *
+     * @return void
+     **/
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                'data_class' => Attempt::class,
+                'characters' => Character::class,
+            ]
+        );
+    }
+}

--- a/src/Repository/AttemptRepository.php
+++ b/src/Repository/AttemptRepository.php
@@ -107,6 +107,24 @@ class AttemptRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    /**
+     * Get the most recent attempt for a character
+     *
+     * @param Character $characterId The character's id
+     *
+     * @return Attempt
+     **/
+    public function getMostRecentAttemptbyCharacter(Character $characterId): Attempt
+    {
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.characterId = :val')
+            ->setParameter('val', $characterId)
+            ->orderBy('a.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     //    /**
     //     * @return Attempt[] Returns an array of Attempt objects
     //     */

--- a/templates/admin/main.html.twig
+++ b/templates/admin/main.html.twig
@@ -36,8 +36,8 @@
             </ul>
             <div class="tab-content" id="adminTabsContent">
                 <div class="tab-pane fade show active" id="update-attempt-pane" role="tabpanel" aria-labelledby="update-attempt" tabindex="0">{{ include('admin/update_attempt.html.twig') }}</div>
-                {# <div class="tab-pane fade" id="new-attempt-pane" role="tabpanel" aria-labelledby="new-attempt" tabindex="0">{{ include('admin/new_attempt.html.twig') }}</div>
-                <div class="tab-pane fade" id="new-character-pane" role="tabpanel" aria-labelledby="new-character" tabindex="0">{{ include('admin/new_character.html.twig') }}</div> #}
+                <div class="tab-pane fade" id="new-attempt-pane" role="tabpanel" aria-labelledby="new-attempt" tabindex="0">{{ include('admin/new_attempt.html.twig') }}</div>
+                {# <div class="tab-pane fade" id="new-character-pane" role="tabpanel" aria-labelledby="new-character" tabindex="0">{{ include('admin/new_character.html.twig') }}</div> #}
             </div>
         </div>
     </div>

--- a/templates/admin/new_attempt.html.twig
+++ b/templates/admin/new_attempt.html.twig
@@ -1,6 +1,5 @@
 <div class="row justify-content-start mt-3 mb-3">
     <div class="col-lg-12 col-xl-12">
-        {{ dump(new_attempt_form) }}
         <form method="{{ new_attempt_form.vars.method }}" id="{{ new_attempt_form.vars.id }}" name="{{ new_attempt_form.vars.full_name }}">
             <div class="mb-3">
                 <label class="form-label" for="{{ new_attempt_form.characterId.vars.id }}">{{ new_attempt_form.characterId.vars.label }}</label>

--- a/templates/admin/new_attempt.html.twig
+++ b/templates/admin/new_attempt.html.twig
@@ -1,22 +1,30 @@
 <div class="row justify-content-start mt-3 mb-3">
-    <form method="post">
-        {% if current_attempt.causeOfDeath == 0 %}
-        <div class="mb-3">
-            <label for="causeOfDeath-1" class="form-label">Cause of Death (on previous attempt)</label>
-            <input id="causeOfDeath-1" class="form-control" type="text" name="causeOfDeath" placeholder="Cause of death">
-        </div>
-        {% endif %}
-        <div class="mb-3">
-            <label for="character-1" class="form-label">Character Select</label>
-            <select class="form-select">
-                <option selected>Select...</option>
-                {% for character in characters %}
-                    <option value="{{ character.id }}">{{ character.name }}</option>
+    <div class="col-lg-12 col-xl-12">
+        {{ dump(new_attempt_form) }}
+        <form method="{{ new_attempt_form.vars.method }}" id="{{ new_attempt_form.vars.id }}" name="{{ new_attempt_form.vars.full_name }}">
+            <div class="mb-3">
+                <label class="form-label" for="{{ new_attempt_form.characterId.vars.id }}">{{ new_attempt_form.characterId.vars.label }}</label>
+                <select class="form-select" id="{{ new_attempt_form.characterId.vars.id }}" name="{{ new_attempt_form.characterId.vars.full_name }}">
+                {% for choice in new_attempt_form.characterId.vars.choices %}
+                <option value="{{ choice.value }}">{{ choice.label }}</option>
                 {% endfor %}
-            </select>
-        </div>
-        <div>
-            <button class="btn btn-secondary d-block w-10" type="submit">Start</button>
-        </div>
-    </form>
+                </select>
+            </div>
+            {% if has_cause_of_death == 0 %}
+            <div class="mb-3">
+                <label class="form-label" for="{{ new_attempt_form.causeOfDeath.vars.id }}">{{ new_attempt_form.causeOfDeath.vars.label }}</label>
+                <input class="form-control" id="{{ new_attempt_form.causeOfDeath.vars.id }}" name="{{ new_attempt_form.causeOfDeath.vars.full_name }}" value="{{ new_attempt_form.causeOfDeath.vars.value }}" type="text" minlength="3" maxlength="255" placeholder="Cause of death">
+                {% if new_attempt_form.causeOfDeath.vars.errors|length > 0 %}
+                <div class="alert alert-danger mt-1" role="alert">
+                    {{ new_attempt_form.causeOfDeath.vars.errors }}
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+            <div class="mb-3">
+                <button class="btn btn-secondary d-block w-10" id="{{ new_attempt_form.submit.vars.id }}" name="{{ new_attempt_form.submit.vars.full_name }}">{{ new_attempt_form.submit.vars.label }}</button>
+            </div>
+            <input id="{{ new_attempt_form.children._token.vars.id }}" name="{{ new_attempt_form.children._token.vars.full_name }}" value="{{ new_attempt_form.children._token.vars.value }}" type="hidden">
+        </form>
+    </div>
 </div>

--- a/templates/admin/update_attempt.html.twig
+++ b/templates/admin/update_attempt.html.twig
@@ -44,9 +44,9 @@
             <div class="mb-3">
                 <label class="form-label" for="{{ update_attempt_form.causeOfDeath.vars.id }}">{{ update_attempt_form.causeOfDeath.vars.label }}</label>
                 <input class="form-control" id="{{ update_attempt_form.causeOfDeath.vars.id }}" name="{{ update_attempt_form.causeOfDeath.vars.full_name }}" value="{{ update_attempt_form.causeOfDeath.vars.value }}" type="text" minlength="3" maxlength="255" placeholder="Cause of death">
-                {% if update_attempt_form.timePlayed.vars.errors|length > 0 %}
+                {% if update_attempt_form.causeOfDeath.vars.errors|length > 0 %}
                 <div class="alert alert-danger mt-1" role="alert">
-                    {{ update_attempt_form.timePlayed.vars.errors }}
+                    {{ update_attempt_form.causeOfDeath.vars.errors }}
                 </div>
                 {% endif %}
             </div>

--- a/templates/players/characters/milestones_achieved.html.twig
+++ b/templates/players/characters/milestones_achieved.html.twig
@@ -7,7 +7,8 @@
                 <a class="header-link" href="#milestones-achieved" title="Permalink to this header">Milestones Achieved</a>
             </h1>
             <div class="row justify-content-center">
-            {% for milestone in milestones %}
+                {% if milestones|length >= 1 %}
+                {% for milestone in milestones %}
                 <div class="col-md-4">
                     <div class="text-center d-flex flex-column justify-content-center align-items-center py-3">
                         <img src="{{ asset('images/milestones/milestone-'~milestone.id~'.webp') }}" class="d-block m-auto" width="48" height="48" title="{{ milestone.name }}" />
@@ -17,7 +18,14 @@
                         </div>
                     </div>
                 </div>
-            {% endfor %}
+                {% endfor %}
+                {% else %}
+                <div class="col-md-12">
+                    <div class="py-3">
+                        <p>No milestones achieved!</p>
+                    </div>
+                </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/templates/players/characters/previous/cause_of_death.html.twig
+++ b/templates/players/characters/previous/cause_of_death.html.twig
@@ -6,7 +6,11 @@
             <h1 id="cause-of-death">
                 <a class="header-link" href="#cause-of-death">Cause of Death</a>
             </h1>
-            <p>{{ attempt.causeOfDeath }}</p>
+            <div class="col-md-12">
+                <div class="py-3">
+                    <p>{{ attempt.causeOfDeath }}</p>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/players/characters/previous/index.html.twig
+++ b/templates/players/characters/previous/index.html.twig
@@ -6,13 +6,13 @@
     {% endblock %}
 
     {% block main %}
-        {{ include('players/characters/title.html.twig') }}
-        {{ include('players/characters/bio.html.twig') }}
-        {{ include('players/characters/roles_and_jobs.html.twig') }}
-        {{ include('players/characters/milestones_achieved.html.twig') }}
-        {{ include('players/characters/cause_of_death.html.twig') }}
-        {{ include('players/characters/character_details.html.twig') }}
-        {{ include('players/characters/previous_attempts.html.twig') }}
+        {{ include('players/characters/previous/title.html.twig') }}
+        {{ include('players/characters/previous/bio.html.twig') }}
+        {{ include('players/characters/previous/roles_and_jobs.html.twig') }}
+        {{ include('players/characters/previous/milestones_achieved.html.twig') }}
+        {{ include('players/characters/previous/cause_of_death.html.twig') }}
+        {{ include('players/characters/previous/character_details.html.twig') }}
+        {{ include('players/characters/previous/previous_attempts.html.twig') }}
     {% endblock %}
 
     {% block footer %}

--- a/templates/players/characters/previous/previous_attempts.html.twig
+++ b/templates/players/characters/previous/previous_attempts.html.twig
@@ -6,17 +6,19 @@
             <h1 id="previous-attempts">
                 <a class="header-link" href="#previous-attempts" title="Permalink to this header">Previous Attempts</a>
             </h1>
-            {% for attempt in character.attempts %}
-            {% if attempt.isCurrent == 0 %}
+            {% if character.attempts|length > 1 %}
             <ul class="list-group">
+                {% for attempt in character.attempts %}
+                {% if attempt.isCurrent == 0 %}
                 <li class="list-group-item">
-                    <a class="list-group-link">Previous Attempt #{{ attempt.attemptNumber }}</a>
+                    <a class="list-group-link" href="/previous/{{ character.id }}/{{ attempt.id }}">Previous Attempt #{{ attempt.attemptNumber }}</a>
                 </li>
+                {% endif %}
+                {% endfor %}
             </ul>
             {% else %}
             <p class="mb-4">No previous attempts!</p>
             {% endif %}
-            {% endfor %}
         </div>
     </div>
 </div>

--- a/templates/players/characters/previous_attempts.html.twig
+++ b/templates/players/characters/previous_attempts.html.twig
@@ -6,17 +6,19 @@
             <h1 id="previous-attempts">
                 <a class="header-link" href="#previous-attempts" title="Permalink to this header">Previous Attempts</a>
             </h1>
-            {% for attempt in character.attempts %}
-            {% if attempt.isCurrent == 0 %}
+            {% if character.attempts|length > 1 %}
             <ul class="list-group">
+                {% for attempt in character.attempts %}
+                {% if attempt.isCurrent == 0 %}
                 <li class="list-group-item">
-                    <a class="list-group-link">Previous Attempt #{{ attempt.attemptNumber }}</a>
+                    <a class="list-group-link" href="/previous/{{ character.id }}/{{ attempt.id }}">Previous Attempt #{{ attempt.attemptNumber }}</a>
                 </li>
+                {% endif %}
+                {% endfor %}
             </ul>
             {% else %}
             <p class="mb-4">No previous attempts!</p>
             {% endif %}
-            {% endfor %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
- added newattempt form, brought new form into admincontroller
- updated newattempt twig template to use the new form
- fixed a bug in updateattempt twig template that referenced the wrong object for an error message
- added database update logic to admincontroller for newattempt form
- updated attemptrepository with a query to get the most recent attempt for a character
- updated characterscontroller with new route
- updated milestones twig template with better spacing and formatting when no milestones exist
- updated cause twig template with better spacing
- updated previous index twig template to include the proper twig templates
- fixed a bug in the previous_attempt twig templates where it both listed no previous attempts and listed previous attempts